### PR TITLE
Update contrast ratios to exact WCAG guidelines

### DIFF
--- a/Stark.sketchplugin/Contents/Resources/Web/js/main.js
+++ b/Stark.sketchplugin/Contents/Resources/Web/js/main.js
@@ -176,7 +176,7 @@ function updateCheckerOutput(contrastResults) {
   contrastRatio.textContent = results[0] + ':1';
 
 
-  if (results[0] >= 3.1) {
+  if (results[0] >= 3.0) {
     document.getElementById('ResultsLargeAaPass').classList.remove('hidden');
     document.getElementById('ResultsLargeAaFail').classList.add('hidden');
   }
@@ -189,12 +189,12 @@ function updateCheckerOutput(contrastResults) {
     document.getElementById('ResultsLargeAaaFail').classList.add('hidden');
   }
 
-  if (results[0] >= 7.1) {
+  if (results[0] >= 7.0) {
     document.getElementById('ResultsNormalAaaPass').classList.remove('hidden');
     document.getElementById('ResultsNormalAaaFail').classList.add('hidden');
   }
 
-  if (results[0] < 3.1) {
+  if (results[0] < 3.0) {
     document.getElementById('ResultsLargeAaPass').classList.add('hidden');
     document.getElementById('ResultsLargeAaFail').classList.remove('hidden');
   }
@@ -207,7 +207,7 @@ function updateCheckerOutput(contrastResults) {
     document.getElementById('ResultsLargeAaaFail').classList.remove('hidden');
   }
 
-  if (results[0] < 7.1) {
+  if (results[0] < 7.0) {
     document.getElementById('ResultsNormalAaaPass').classList.add('hidden');
     document.getElementById('ResultsNormalAaaFail').classList.remove('hidden');
   }


### PR DESCRIPTION
As per [this page](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).

Fixes issue where contrast would be above acceptable threshold but still display as failing.

<img width="663" alt="screen shot 2017-04-25 at 8 05 13 am" src="https://cloud.githubusercontent.com/assets/1166226/25392770/6e14b220-298e-11e7-82ac-266aad1e71eb.png">
